### PR TITLE
fix: Remove modal memory leaks

### DIFF
--- a/packages/common/src/components/Modal/Modal.tsx
+++ b/packages/common/src/components/Modal/Modal.tsx
@@ -71,7 +71,7 @@ const useVisibilityChangeHandler = (
 };
 
 const useScrollLock = (isVisible: boolean) => {
-  return React.useEffect(() => {
+  return React.useLayoutEffect(() => {
     // Add or remove style to prevent scrolling
     if (isVisible) {
       document.body.classList.add(styles.preventScrolling);

--- a/packages/common/src/components/Modal/Modal.tsx
+++ b/packages/common/src/components/Modal/Modal.tsx
@@ -42,14 +42,14 @@ const useEscapePressed = (
   const onEscapePressedCallback = useEscapePressedCallback(onEscapePressed);
   React.useLayoutEffect(() => {
     // Save for unmount closure
-    const wasVisble = isVisible;
+    const wasVisible = isVisible;
     // Add callback only when the component was visible
-    if (wasVisble == true) {
+    if (isVisible == true) {
       document.addEventListener("keydown", onEscapePressedCallback);
     }
     return () => {
       // Read closure value and remove listener if it was added
-      if (wasVisble == true) {
+      if (wasVisible == true) {
         document.removeEventListener("keydown", onEscapePressedCallback);
       }
     };
@@ -96,7 +96,7 @@ const Modal = React.memo((props: React.PropsWithChildren<IModalProps>) => {
   );
   useScrollLock(props.isVisible);
   return (
-    <ModalPortal>
+    <ModalPortal isVisible={props.isVisible}>
       <ModalBackdrop
         isVisible={props.isVisible}
         onBackdropClick={props.onBackdropClick}

--- a/packages/common/src/components/Modal/Modal.tsx
+++ b/packages/common/src/components/Modal/Modal.tsx
@@ -71,7 +71,7 @@ const useVisibilityChangeHandler = (
 };
 
 const useScrollLock = (isVisible: boolean) => {
-  return React.useLayoutEffect(() => {
+  return React.useEffect(() => {
     // Add or remove style to prevent scrolling
     if (isVisible) {
       document.body.classList.add(styles.preventScrolling);


### PR DESCRIPTION
* Attach keydown listeners only when the modal is visible.

This closes #57
